### PR TITLE
User confirmation prompt and force flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ To install, use [basher](https://github.com/basherpm/basher):
 
 Tests are written with [bats](https://github.com/sstephenson/bats):
 
-    bats test/tests/bats
-    
+    bats test/tests.bats
+
 It even comes with a man page!
 
     man emptydir

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # emptydir [![Build Status](https://travis-ci.org/adamserafini/emptydir.svg?branch=master)](https://travis-ci.org/adamserafini/emptydir)
 *nix shell command for emptying directories.
 
-    usage: emptydir [-a] directory ...
+    usage: emptydir [-af] directory ...
 
-The `-a` option also removes any hidden files or subdirectories.
+The `-a` (all) option also removes any hidden files or subdirectories. By
+default, `emptydir` prompts for confirmation before emptying a directory. This can be suppressed with the `-f` (force) flag.
 
 To install, use [basher](https://github.com/basherpm/basher):
 

--- a/bin/emptydir
+++ b/bin/emptydir
@@ -20,30 +20,75 @@ emptyhidden() {
 
   #	 1/ $1/..?* removes all dot-dot files and subdirs except '..'
   #	 2/ $1/.[!.]* removes all dot files and subdirs except '.'
+
   rm -rf $1/..?* $1/.[!.]*
 }
 
 empty() {
   # Remove visible files and subdirectories from a directory.
+
   rm -rf $1/*
 }
 
+abspath() {
+  # Echo the absolute path of a directory path argument.
+
+  echo $(cd $1; pwd)
+}
+
+emptypath() {
+  # Handle the full logic for emptying a path including user confirmation,
+  # validity test and error reporting.
+
+  if [ -d "$1" ]; then
+    # Convert to absolute path.
+    local path=$(abspath $1)
+
+    # Prompt for confirmation if the user hasn't set the -f flag.
+    if [ "$force" = false ]; then
+      read -p "empty ${path}? " -r
+      if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        # Exit the function early if the user does not confirm.
+        return
+      fi
+    fi
+
+    empty $path
+    # If -a flag was passed also remove hidden files and dirs.
+    if [ "$remove_hidden" = true ]; then
+      emptyhidden $path
+    fi
+
+  elif [ -f "$path" ]; then
+    # It was a valid path but it wasn't a directoy.
+    echo "emptydir: $path: Not a directory" >&2
+    retval=1
+
+  else
+    echo "emptydir: $path: No such file or directory" >&2
+    retval=1
+  fi
+}
+
 main() {
-  # Store the cmd name in a variable (for error reporting).
-  cmdname=emptydir
-
-  # By default, do not empty the directory of hidden files or subdirectories.
+  # By default, do not empty the directory of hidden files or subdirectories
+  # but do prompt for confirmation.
   local remove_hidden=false
+  local force=false
 
-  # Parse the options. The only valid option is -a (all) which empties the
-  # directory of hidden files and subdirectories.
-  while getopts ":a" opt; do
+  # Parse the options. The only valid options are -a (all) which empties the
+  # directory of hidden files and subdirectories and -f (force) which suppresses
+  # any confirmation from the user.
+  while getopts ":af" opt; do
     case $opt in
       a)
         remove_hidden=true
         ;;
+      f)
+        force=true
+        ;;
       \?)
-        echo "$cmdname: illegal option: -- $OPTARG" >&2
+        echo "emptydir: illegal option: -- $OPTARG" >&2
         usage
         ;;
     esac
@@ -57,25 +102,12 @@ main() {
     usage
   fi
 
-  # Script returns 0 if all directories emptied, else 1.
+  # Script returns 0 if all confirmed directories were emptied, else 1.
   retval=0
   # Loop through the directory arguments.
   for path in "$@"
   do
-    if [ -d "$path" ]; then
-      empty $path
-      # If -a flag was passed also remove hidden files and dirs.
-      if [ "$remove_hidden" = true ]; then
-        emptyhidden $path
-      fi
-    elif [ -f "$path" ]; then
-      # It was a valid path but it wasn't a directoy.
-      echo "$cmdname: $path: Not a directory" >&2
-      retval=1
-    else
-      echo "$cmdname: $path: No such file or directory" >&2
-      retval=1
-    fi
+    emptypath $path
   done
 
   exit $retval

--- a/man/emptydir.1
+++ b/man/emptydir.1
@@ -1,7 +1,7 @@
 .\" Copyright (c) 2016
 .\"	Adam Serafini.  All rights reserved.
 .\"
-.\"	@(#)emptydir.1	1.0 (Adam Serafini) 30/07/16
+.\"	@(#)emptydir.1	1.1 (Adam Serafini) 30/07/16
 .\"
 .Dd July 30,2016
 .Dt EMPTYDIR 1
@@ -11,7 +11,7 @@
 .Nd empty directories
 .Sh SYNOPSIS
 .Nm
-.Op Fl a
+.Op Fl af
 .Ar directory ...
 .Sh DESCRIPTION
 The
@@ -23,12 +23,14 @@ argument.
 .Pp
 Arguments are processed in the order given.
 .Pp
-The following option is available:
+The following options are available:
 .Bl -tag -width indent
 .It Fl a
 Hidden files or subdirectories in each
 .Ar directory
 argument are also removed.
+.It Fl f
+Confirmation prompt is suppressed.
 .El
 .Pp
 The

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -50,17 +50,17 @@ setup() {
   [ -f tmp/file ]
 }
 
-@test "invoking without -a argument removes normal files and dirs" {
-  run bin/emptydir tmp
+@test "invoking without -a flag removes normal files and dirs" {
+  run bin/emptydir -f tmp
   [ "$status" -eq 0 ]
   [ -f tmp/.hiddenfile ]
   [ -d tmp/.hiddendir ]
   [ ! -f tmp/file ]
   [ ! -d tmp/dir ]
 }
-
-@test "invoking with -a argument removes all files and dirs" {
-  run bin/emptydir -a tmp
+atom
+@test "invoking with -a flag removes all files and dirs" {
+  run bin/emptydir -af tmp
   [ "$status" -eq 0 ]
   [ ! -f tmp/.hiddenfile ]
   [ ! -d tmp/.hiddendir ]
@@ -69,7 +69,7 @@ setup() {
 }
 
 @test "invoking with invalid and valid dir returns error" {
-  run bin/emptydir tmp notexist
+  run bin/emptydir -f tmp notexist
   [ "$status" -eq 1 ]
   [ "$output" = "emptydir: notexist: No such file or directory" ]
 

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -58,7 +58,7 @@ setup() {
   [ ! -f tmp/file ]
   [ ! -d tmp/dir ]
 }
-atom
+
 @test "invoking with -a flag removes all files and dirs" {
   run bin/emptydir -af tmp
   [ "$status" -eq 0 ]

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1,12 +1,13 @@
 #!/usr/bin/env bats
 
-setup() {
-  mkdir tmp tmp/.hiddendir tmp/dir
-  touch tmp/.hiddenfile tmp/file
-}
-
 teardown() {
   rm -rf tmp
+}
+
+setup() {
+  teardown
+  mkdir tmp tmp/.hiddendir tmp/dir
+  touch tmp/.hiddenfile tmp/file
 }
 
 @test "invoking emptydir with no arguments prints usage" {

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -77,3 +77,15 @@ atom
   [ ! -f tmp/file ]
   [ ! -d tmp/dir ]
 }
+
+@test "invoking without -f flag and with confirmation empties the dir" {
+  run bash -c "yes | bin/emptydir tmp"
+  [ ! -f tmp/file ]
+  [ ! -d tmp/dir ]
+}
+
+@test "invoking without -f flag and without confirmation does not empty" {
+  run bash -c "yes no | bin/emptydir tmp"
+  [ -f tmp/file ]
+  [ -d tmp/dir ]
+}


### PR DESCRIPTION
As this command is potentially dangerous (consider emptydir /), it would be prudent to check for confirmation before emptying a directory. We also introduce a new -force flag to suppress the confirmation.